### PR TITLE
Fix 'undefined variable filestyle_activate'

### DIFF
--- a/plugin/filestyle.vim
+++ b/plugin/filestyle.vim
@@ -100,7 +100,7 @@ endfunction
 
 "Checking file dependenly on settings
 function FileStyleCheck()
-  if b:filestyle_active == 1
+  if get(b:, "filestyle_active", 0) == 1
     call clearmatches()
     call FileStyleExpandtabCheck()
     call FileStyleTrailingSpaces()


### PR DESCRIPTION
When I open any file, I get this message:

```
Error detected while processing function FileStyleCheck:
line    1:
E121: Undefined variable: b:filestyle_active
```

I fixed it through the `get()` function
