### PR TITLE
Leave cursor in the same position after fixing

### DIFF
--- a/plugin/filestyle.vim
+++ b/plugin/filestyle.vim
@@ -249,7 +249,11 @@ endfunction!
 
 "Remove trailing spaces
 function! FileStyleTrailngSpacesFix()
+  let s:buffer_status = @p
+  silent! execute 'norm! mz'
   silent! execute '%s/\s\+$//'
+  silent! execute 'norm! `z'
+  let @p = s:buffer_status
 endfunction!
 
 


### PR DESCRIPTION
- When execute `FileStyleFix` the trailing white space fixing operation now leaves the cursor in the starting position

- Temporal buffer used is properly restored