### PR TITLE
Leave cursor in the same position after fixing

### DIFF
--- a/plugin/filestyle.vim
+++ b/plugin/filestyle.vim
@@ -249,7 +249,9 @@ endfunction!
 
 "Remove trailing spaces
 function! FileStyleTrailngSpacesFix()
+  silent! execute 'norm! mz'
   silent! execute '%s/\s\+$//'
+  silent! execute 'norm! `z'
 endfunction!
 
 


### PR DESCRIPTION
- After executing a `FileStyleFix` the trailing white space operation leave the cursor at the starting position so the user is not disoriented 