### PR TITLE
Remove blank lines at the end of the file

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,8 @@ Usage
 
 1. Remove control characters
 2. Remove trailing spaces
-3. If `'expandtab'` is set, replace tabs with spaces, if not, replace spaces
+3. Remove blank lines at the end of the file
+4. If `'expandtab'` is set, replace tabs with spaces, if not, replace spaces
    at the beginning of a line with tabs
 
 ##### Ignore file types

--- a/plugin/filestyle.vim
+++ b/plugin/filestyle.vim
@@ -1,3 +1,6 @@
+
+
+
 "   Copyright 2014 Alexander Serebryakov
 "
 "   Licensed under the Apache License, Version 2.0 (the "License");
@@ -253,6 +256,14 @@ function! FileStyleTrailngSpacesFix()
 endfunction!
 
 
+"Remove blank lines at the end of the file
+function! FileStyleBlankLinesFix()
+  silent! execute 'norm! mz'
+  silent! execute 'g/\v^$\n*%$/norm! dd'
+  silent! execute 'norm! `z'
+endfunction!
+
+
 "Function iterating over entire buffer and processing each
 "line with a given function
 function! FileStyleDoForEachLine(function)
@@ -311,6 +322,7 @@ function! FileStyleFix()
   call FileStyleControlCharactersFix()
   call FileStyleTrailngSpacesFix()
   call FileStyleExpandtabFix()
+  call FileStyleBlankLinesFix()
 endfunction!
 
 


### PR DESCRIPTION
Blank lines at the end of the file looks pretty ugly and neglected

* Leaves the cursor where it was before `FileStyleFix` invocation