### PR TITLE
Fixed tag and version number in help file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,10 @@ License
 Changelog
 ---------
 
+#### 1.1.2
+
+* Fixed tag and version number in help file
+
 #### 1.1.1
 
 * Fixed cursor positioning after FileStyleFix call

--- a/doc/filestyle.txt
+++ b/doc/filestyle.txt
@@ -1,4 +1,5 @@
-*filestyle.txt*    Version 1.0.0
+*filestyle.txt*    Version 1.1.2
+*filestyle*
 
 Highlights unwanted whitespace and characters.
 
@@ -161,6 +162,10 @@ limitations under the License.
 
 ==============================================================================
 6. Changelog                                              *FileStyleChangelog*
+
+1.1.2
+
+* Fixed tag and version number in help file
 
 1.1.1
 


### PR DESCRIPTION
This fixes `:he filestyle` and the version number at the top of `filestyle.txt`, which was still 1.0.0.