### PR TITLE
Define ctermbg parameter if cleared

### DIFF
--- a/plugin/filestyle.vim
+++ b/plugin/filestyle.vim
@@ -33,9 +33,12 @@ function! FileStyleCreateIgnoredPatternGroup()
 
   let l:normal_group = substitute(l:normal_group, '\n', '', 'g')
 
+  "ctermbg parameter should be defined explicitly
   if (match(l:normal_group, 'ctermbg=') == -1)
-    echom 'FileStyle: ctermbg parameter should be defined explicitly'
-    return
+    let l:normal_group = substitute(l:normal_group,
+                                  \ 'cleared',
+                                  \ 'ctermbg=none',
+                                  \ '')
   endif
 
   let l:ignored_group = substitute(l:normal_group,


### PR DESCRIPTION
Hi!

I have an issue with a plain Vim configuration where only the Vundle and Filestyle plugins are installed. No other modification whatsoever.

When I start Vim (not gVim) I get the following error:
```
FileStyle: ctermbg parameter should be defined explicitly
Press ENTER or type command to continue
```

I don’t really understand why the ctermbg parameter is not set, but it seems expected with the default colorscheme:
```
:hi Normal
Normal           xxx cleared
```

This is on a FreeBSD virtual machine. I’ve tried with the plain CSH shell:
```
:echo &term
xterm
```

Same error within a tmux session: 
```
:echo &term
screen
```

Anyway, the attached patch resolves the issue for me, but I would not be surprised if it broke another functionality, as this is quite over my head.

Hope it helps!